### PR TITLE
feat/qgc_support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,18 +7,22 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(MAVSDK REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(Threads REQUIRED)
+find_package(Curses REQUIRED)
 
 add_executable(orbis
     src/main.cpp
     src/monitor.cpp
+    src/qgc_bridge.cpp
 )
 
 target_include_directories(orbis PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CURSES_INCLUDE_DIR}
 )
 
 target_link_libraries(orbis PRIVATE
     MAVSDK::mavsdk
     Boost::system
     Threads::Threads
+    ${CURSES_LIBRARIES}
 )

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,26 @@ FROM arm64v8/debian:12-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
-    wget \
-    cmake \
-    build-essential \
-    libboost-all-dev \
-    && rm -rf /var/lib/apt/lists/*
+    wget cmake build-essential libboost-all-dev \
+    git meson ninja-build pkg-config libsystemd-dev \
+    libncurses-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && printf 'Name: systemd\nDescription: systemd\nVersion: 252\nLibs: -lsystemd\nCflags: -I/usr/include/systemd\nsystemdsystemunitdir=/lib/systemd/system\nsystemduserunitdir=/lib/systemd/user\n' \
+       > /usr/lib/pkgconfig/systemd.pc
 
 RUN wget https://github.com/mavlink/MAVSDK/releases/download/v3.9.0/libmavsdk-dev_3.9.0_debian12_arm64.deb && \
     apt-get install -y ./libmavsdk-dev_3.9.0_debian12_arm64.deb && \
     rm libmavsdk-dev_3.9.0_debian12_arm64.deb
 
+RUN git clone --recurse-submodules --shallow-submodules \
+        https://github.com/mavlink-router/mavlink-router.git /tmp/mlr \
+    && cd /tmp/mlr && meson setup build && ninja -C build \
+    && cp build/src/mavlink-routerd /usr/local/bin/ \
+    && rm -rf /tmp/mlr
+
 WORKDIR /workspace
 
 COPY . .
-COPY CMakeLists.txt .
 
 RUN mkdir build && cd build && \
     cmake .. && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,22 @@ FROM arm64v8/debian:12-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG MAVSDK_VERSION=3.17.0
+ARG MLR_VERSION=v4
+
 RUN apt-get update && apt-get install -y \
-    wget cmake build-essential libboost-all-dev \
-    git meson ninja-build pkg-config libsystemd-dev \
-    libncurses-dev \
+    wget cmake build-essential \
+    git meson ninja-build pkg-config \
+    libboost-all-dev libncurses-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && printf 'Name: systemd\nDescription: systemd\nVersion: 252\nLibs: -lsystemd\nCflags: -I/usr/include/systemd\nsystemdsystemunitdir=/lib/systemd/system\nsystemduserunitdir=/lib/systemd/user\n' \
+    && printf 'Name: systemd\nDescription: systemd\nVersion: 9\nLibs: -lsystemd\nCflags: -I/usr/include/systemd\nsystemdsystemunitdir=/lib/systemd/system\nsystemduserunitdir=/lib/systemd/user\n' \
        > /usr/lib/pkgconfig/systemd.pc
 
-RUN wget https://github.com/mavlink/MAVSDK/releases/download/v3.9.0/libmavsdk-dev_3.9.0_debian12_arm64.deb && \
-    apt-get install -y ./libmavsdk-dev_3.9.0_debian12_arm64.deb && \
-    rm libmavsdk-dev_3.9.0_debian12_arm64.deb
+RUN wget https://github.com/mavlink/MAVSDK/releases/download/v${MAVSDK_VERSION}/libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb && \
+    apt-get install -y ./libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb && \
+    rm libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb
 
-RUN git clone --recurse-submodules --shallow-submodules \
+RUN git clone --recurse-submodules --shallow-submodules --branch ${MLR_VERSION} \
         https://github.com/mavlink-router/mavlink-router.git /tmp/mlr \
     && cd /tmp/mlr && meson setup build && ninja -C build \
     && cp build/src/mavlink-routerd /usr/local/bin/ \

--- a/README.md
+++ b/README.md
@@ -1,48 +1,119 @@
 # Orbis
-A drone using SLAM to map its surroundings, all controlled using a ROG Ally.
+An autonomous drone that maps and navigates its environment using SLAM.
+
+---
+
+## Requirements
+
+### Hardware
+- **Drone side:** Any ARM64 onboard computer acting as a MAVLink bridge, with any MAVLink-compatible flight controller connected via serial
+- **Ground station:** Any machine capable of running Orbis and QGroundControl, networked to the drone
+
+### Software
+- Docker with Compose v2
+- QGroundControl
+
+---
 
 ## Configuration
-Edit `common/config.yaml` before running:
+Edit `common/config.yaml` before building:
 ```yaml
-connection_url: serial:///dev/ttyACM0:57600  # USB path to Pixhawk
-qgc_ip: 192.168.1.x                          # IP of the machine running QGroundControl
+serial_device: /dev/ttyACM0  # serial device path to the flight controller
+serial_baud: 57600           # baud rate of the serial connection
 ```
 
-## Features
-- **Connect QGroundControl** — bridges MAVLink from the Pixhawk over UDP to QGroundControl on your laptop (port 14550)
-- **Telemetry monitoring** — live flight mode and battery readouts via MAVSDK
+---
 
-## Instructions
-1. Set `qgc_ip` in `common/config.yaml` to your laptop's IP.
-2. Run Orbis and select **1. Connect QGroundControl**.
-3. Open QGroundControl — it will connect automatically over UDP port 14550.
+## Commands
 
-## Build
-Build the `orbis` service image:
+**Build:**
 ```bash
 docker compose build orbis
 ```
 
-## Down
-Stop and remove containers, networks, and orphans:
-```bash
-docker compose down --remove-orphans
-```
-
-## Run
-Run the main service interactively (removes container after exit):
+**Run** (interactive, removed on exit):
 ```bash
 docker compose run --rm orbis
 ```
 
-## Prune
-Nuke everything unused:
+**Stop and remove containers:**
+```bash
+docker compose down --remove-orphans
+```
+
+**Nuke all unused Docker resources:**
 ```bash
 docker system prune -a --volumes
 ```
 
-## Force Stop
-Kill docker:
+**Force-kill all running containers:**
 ```bash
 docker kill $(docker ps -q)
 ```
+
+---
+
+## QGroundControl
+
+1. Make sure Orbis is running on the ground station and the drone is powered on.
+2. In QGroundControl: **Application Settings → Comm Links → Add → UDP**.
+3. Set the server address to the drone-side bridge computer's IP and port **14550**.
+4. Click Connect — QGC will link up and the header bar in Orbis will turn green.
+
+---
+
+## Architecture
+
+> This section documents how the system is built. It will grow as the project expands.
+
+### Stack
+
+| Component | Version | Role |
+|---|---|---|
+| Debian slim | 12 (Bookworm) | Base Docker image (`arm64v8`) |
+| MAVSDK | 3.17.0 | High-level MAVLink SDK — telemetry, commands |
+| mavlink-router | v4 | Low-level MAVLink packet forwarder |
+| Boost.Asio | system | Async event loop, timers, signal handling |
+| ncurses | system | Terminal UI |
+
+---
+
+### MAVLink routing
+
+The flight controller speaks MAVLink over a serial connection. Two consumers need that stream simultaneously — MAVSDK (for telemetry and control) and QGroundControl (for full ground station visibility). A single serial port can only be opened once, so **mavlink-router** acts as a transparent byte-level forwarder.
+
+The Pi runs only mavlink-router — it is a dumb MAVLink bridge. All application logic (Orbis, QGC, and eventually SLAM) runs on the ground station.
+
+```
+[ Drone ]
+  Flight controller
+        │ serial
+        ▼
+  Pi — mavlink-router
+        │ UDP (network)
+        ▼
+[ Ground station ]
+  ┌─────┴──────┐
+  ▼            ▼
+:14550       :14551
+ QGC         MAVSDK (Orbis)
+```
+
+---
+
+### MAVSDK
+
+MAVSDK connects to mavlink-router's output on `udpin://0.0.0.0:14551`. It is configured as a `CompanionComputer` (not a GCS), which keeps it from interfering with QGC's GCS role.
+
+---
+
+## Discussions
+
+Have questions, ideas, or want to follow along? Join the conversation:
+[github.com/9LogM/Orbis/discussions](https://github.com/9LogM/Orbis/discussions)
+
+---
+
+## Special Thanks
+
+This project was built with the help of [Claude](https://claude.ai) — cheers for the pair programming.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # Orbis
 A drone using SLAM to map its surroundings, all controlled using a ROG Ally.
 
-## NOTE
-**This project has been officially retired. My focus has since shifted toward autonomous vehicles.**
+## Configuration
+Edit `common/config.yaml` before running:
+```yaml
+connection_url: serial:///dev/ttyACM0:57600  # USB path to Pixhawk
+qgc_ip: 192.168.1.x                          # IP of the machine running QGroundControl
+```
+
+## Features
+- **Connect QGroundControl** — bridges MAVLink from the Pixhawk over UDP to QGroundControl on your laptop (port 14550)
+- **Telemetry monitoring** — live flight mode and battery readouts via MAVSDK
+
+## Instructions
+1. Set `qgc_ip` in `common/config.yaml` to your laptop's IP.
+2. Run Orbis and select **1. Connect QGroundControl**.
+3. Open QGroundControl — it will connect automatically over UDP port 14550.
 
 ## Build
 Build the `orbis` service image:

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,1 +1,2 @@
-connection_url:
+serial_device: /dev/ttyACM0
+serial_baud: 57600

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,5 +2,6 @@ services:
   orbis:
     build: .
     container_name: "orbis_container"
+    network_mode: host
     devices:
       - "/dev/ttyACM0:/dev/ttyACM0"

--- a/include/monitor.hpp
+++ b/include/monitor.hpp
@@ -8,9 +8,10 @@ namespace mavsdk { class Telemetry; }
 struct TelemetrySnapshot {
     // Status
     bool        armed        = false;
-    std::string flight_mode  = "—";
+    std::string flight_mode  = "N/A";
     // Power
-    int         battery_pct  = -1;
+    bool        has_battery  = false;
+    int         battery_pct  = 0;
     float       battery_v    = 0;
     // Position
     bool        has_fix      = false;

--- a/include/monitor.hpp
+++ b/include/monitor.hpp
@@ -1,11 +1,31 @@
 #pragma once
+#include <functional>
+#include <string>
+#include <memory>
 
-namespace mavsdk {
-    class Telemetry;
-}
+namespace mavsdk { class Telemetry; }
 
-/**
- * @brief Sets up subscriptions to MAVSDK telemetry data.
- * @param telemetry A reference to the Telemetry plugin object.
- */
-void setup_monitoring(mavsdk::Telemetry &telemetry);
+struct TelemetrySnapshot {
+    // Status
+    bool        armed        = false;
+    std::string flight_mode  = "—";
+    // Power
+    int         battery_pct  = -1;
+    float       battery_v    = 0;
+    // Position
+    bool        has_fix      = false;
+    double      latitude     = 0;
+    double      longitude    = 0;
+    float       abs_alt_m    = 0;
+    float       rel_alt_m    = 0;
+    // Attitude
+    float       roll_deg     = 0;
+    float       pitch_deg    = 0;
+    float       yaw_deg      = 0;
+    // Speed
+    float       ground_spd   = 0;  // m/s
+};
+
+void setup_monitoring(mavsdk::Telemetry& telemetry,
+                      std::shared_ptr<TelemetrySnapshot> snap,
+                      std::function<void()> on_update);

--- a/include/qgc_bridge.hpp
+++ b/include/qgc_bridge.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <string>
+#include <sys/types.h>
+
+pid_t start_mavlink_router(const std::string& serial_device, int baud);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,161 +1,396 @@
 #include <iostream>
+#include <fstream>
+#include <sstream>
 #include <memory>
 #include <future>
-#include <functional>
-#include <csignal>
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <string>
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 
+// Boost before ncurses — ncurses defines macros (timeout, clear, move…)
+// that conflict with Boost ASIO if included first
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/system.h>
 #include <mavsdk/plugins/telemetry/telemetry.h>
+#include <mavsdk/log_callback.h>
 #include <boost/asio.hpp>
-#include <boost/asio/posix/stream_descriptor.hpp>
-#include <boost/bind/bind.hpp>
+
+#include <ncurses.h>
 
 #include "monitor.hpp"
+#include "qgc_bridge.hpp"
 
 using namespace mavsdk;
 
+// ── Config ────────────────────────────────────────────────────────────────────
+
+static std::map<std::string, std::string> load_config(const std::string& path) {
+    std::map<std::string, std::string> result;
+    std::ifstream file(path);
+    if (!file.is_open()) return result;
+
+    auto trim = [](std::string& s) {
+        s.erase(0, s.find_first_not_of(" \t\r\n"));
+        auto pos = s.find_last_not_of(" \t\r\n");
+        if (pos != std::string::npos) s.erase(pos + 1);
+        else s.clear();
+    };
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        auto colon = line.find(':');
+        if (colon == std::string::npos) continue;
+        std::string key = line.substr(0, colon);
+        std::string value = line.substr(colon + 1);
+        trim(key); trim(value);
+        if (!key.empty()) result[key] = value;
+    }
+    return result;
+}
+
+static std::map<std::string, std::string> try_load_config() {
+    for (const std::string& path : {"common/config.yaml", "../common/config.yaml"}) {
+        auto c = load_config(path);
+        if (!c.empty()) return c;
+    }
+    return {};
+}
+
+static std::string get_local_ip() {
+    struct ifaddrs* ifaddr;
+    if (getifaddrs(&ifaddr) == -1) return "unknown";
+    std::string result = "unknown";
+    for (auto* ifa = ifaddr; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET) continue;
+        if (std::string(ifa->ifa_name) == "lo") continue;
+        char buf[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &reinterpret_cast<sockaddr_in*>(ifa->ifa_addr)->sin_addr, buf, sizeof(buf));
+        result = buf;
+        break;
+    }
+    freeifaddrs(ifaddr);
+    return result;
+}
+
+// ── App state ─────────────────────────────────────────────────────────────────
+
+enum class State { MainMenu, SubMenu, Monitoring };
+
 struct AppContext {
-    boost::asio::io_context io_context;
-    boost::asio::signal_set signals;
-    boost::asio::posix::stream_descriptor input;
-    boost::asio::streambuf buffer;
+    boost::asio::io_context      io;
+    boost::asio::signal_set      signals;
+    boost::asio::steady_timer    input_timer;
+    boost::asio::steady_timer    qgc_watchdog;
+    boost::asio::steady_timer    render_timer;
+    bool                         render_dirty = false;
 
-    std::shared_ptr<System> system;
-    std::unique_ptr<PluginBase> pointer;
-    
-    enum State { MainMenu, NotMainMenu } current_state;
+    Mavsdk&                      sdk;
+    std::shared_ptr<System>      system;
+    std::unique_ptr<PluginBase>  telemetry_plugin;
 
-    AppContext(std::shared_ptr<System> system) :
-        signals(io_context, SIGINT),
-        input(io_context, ::dup(STDIN_FILENO)),
-        system(system),
-        current_state(State::MainMenu) {}
+    State        state         = State::MainMenu;
+    bool         qgc_connected = false;
+    std::string  input_line;
+    std::string  sub_content;
+    std::shared_ptr<TelemetrySnapshot> telemetry_snap = std::make_shared<TelemetrySnapshot>();
+
+    AppContext(Mavsdk& sdk, std::shared_ptr<System> system)
+        : signals(io, SIGINT)
+        , input_timer(io)
+        , qgc_watchdog(io)
+        , render_timer(io)
+        , sdk(sdk)
+        , system(system) {}
 };
 
-void display_main_menu();
-void process_command(AppContext &ctx, const std::string &command);
-void on_input_received(AppContext &ctx, const boost::system::error_code &error);
-void start_reading_input(AppContext &ctx);
-void start_monitoring(AppContext &ctx);
+// ── Drawing ───────────────────────────────────────────────────────────────────
+
+static void draw_header(const AppContext& ctx) {
+    int cols = getmaxx(stdscr);
+
+    attron(A_BOLD);
+    mvhline(0, 0, '=', cols);
+    attroff(A_BOLD);
+
+    mvprintw(1, 2, "ORBIS");
+
+    std::string label = "QGC: ";
+    std::string status = ctx.qgc_connected ? "Connected" : "Waiting...";
+    int right_col = cols - (int)(label.size() + status.size()) - 2;
+    mvprintw(1, right_col, "%s", label.c_str());
+    if (ctx.qgc_connected) attron(COLOR_PAIR(1) | A_BOLD);
+    else                   attron(COLOR_PAIR(2));
+    printw("%s", status.c_str());
+    attroff(COLOR_PAIR(1) | COLOR_PAIR(2) | A_BOLD);
+
+    attron(A_BOLD);
+    mvhline(2, 0, '=', cols);
+    attroff(A_BOLD);
+}
+
+static void start_render_loop(AppContext& ctx);
+
+static void request_render(AppContext& ctx) {
+    if (!ctx.render_dirty) {
+        ctx.render_dirty = true;
+        start_render_loop(ctx);
+    }
+}
+
+static void render(const AppContext& ctx) {
+    int rows = getmaxy(stdscr);
+    int cols = getmaxx(stdscr);
+    erase();
+    draw_header(ctx);
+
+    if (ctx.state == State::MainMenu) {
+        mvprintw(4, 2, "1. QGroundControl");
+        mvprintw(5, 2, "2. Telemetry monitor");
+        attron(A_DIM);
+        mvhline(rows - 3, 0, '-', cols);
+        mvprintw(rows - 2, 2, "Ctrl+C to exit");
+        attroff(A_DIM);
+
+    } else if (ctx.state == State::SubMenu) {
+        int row = 4;
+        std::istringstream ss(ctx.sub_content);
+        std::string line;
+        while (std::getline(ss, line))
+            mvprintw(row++, 0, "%s", line.c_str());
+
+    } else if (ctx.state == State::Monitoring) {
+        const auto& s = *ctx.telemetry_snap;
+        int r = 4;
+
+        // Status
+        attron(A_BOLD); mvprintw(r++, 2, "Status"); attroff(A_BOLD);
+        mvprintw(r++, 4, "Armed       : %s", s.armed ? "Yes" : "No");
+        mvprintw(r++, 4, "Flight mode : %s", s.flight_mode.c_str());
+        r++;
+
+        // Power
+        attron(A_BOLD); mvprintw(r++, 2, "Power"); attroff(A_BOLD);
+        if (s.battery_pct >= 0)
+            mvprintw(r++, 4, "Battery     : %d%%  (%.1f V)", s.battery_pct, s.battery_v);
+        else
+            mvprintw(r++, 4, "Battery     : —");
+        r++;
+
+        // Position
+        attron(A_BOLD); mvprintw(r++, 2, "Position"); attroff(A_BOLD);
+        if (s.has_fix) {
+            mvprintw(r++, 4, "Latitude    : %.6f", s.latitude);
+            mvprintw(r++, 4, "Longitude   : %.6f", s.longitude);
+            mvprintw(r++, 4, "Altitude    : %.1f m (rel: %.1f m)", s.abs_alt_m, s.rel_alt_m);
+        } else {
+            mvprintw(r++, 4, "No GPS fix");
+        }
+        r++;
+
+        // Attitude
+        attron(A_BOLD); mvprintw(r++, 2, "Attitude"); attroff(A_BOLD);
+        mvprintw(r++, 4, "Roll        : %.1f°", s.roll_deg);
+        mvprintw(r++, 4, "Pitch       : %.1f°", s.pitch_deg);
+        mvprintw(r++, 4, "Yaw         : %.1f°", s.yaw_deg);
+        r++;
+
+        // Speed
+        attron(A_BOLD); mvprintw(r++, 2, "Speed"); attroff(A_BOLD);
+        mvprintw(r++, 4, "Ground      : %.1f m/s", s.ground_spd);
+
+        attron(A_DIM);
+        mvprintw(rows - 2, 2, "Press Enter to return.");
+        attroff(A_DIM);
+    }
+
+    // Input prompt
+    mvprintw(rows - 1, 0, "> %s", ctx.input_line.c_str());
+    move(rows - 1, 2 + (int)ctx.input_line.size());
+    refresh();
+}
+
+// ── Render loop (rate-limited to ~30fps) ──────────────────────────────────────
+
+static void start_render_loop(AppContext& ctx) {
+    ctx.render_timer.expires_after(std::chrono::milliseconds(33));
+    ctx.render_timer.async_wait([&ctx](const boost::system::error_code& ec) {
+        if (ec || ctx.io.stopped()) return;
+        if (ctx.render_dirty) {
+            ctx.render_dirty = false;
+            render(ctx);
+        }
+    });
+}
+
+// ── Commands ──────────────────────────────────────────────────────────────────
+
+static void process_command(AppContext& ctx, const std::string& cmd) {
+    if (ctx.state == State::MainMenu) {
+        if (cmd.empty()) return;
+
+        int choice = 0;
+        try { choice = std::stoi(cmd); } catch (...) {}
+
+        switch (choice) {
+            case 1: {
+                std::string ip = get_local_ip();
+                ctx.sub_content =
+                    "  QGROUNDCONTROL\n\n"
+                    "  Connect QGC on your laptop:\n"
+                    "    Comm Links -> Add -> UDP\n"
+                    "    Server address : " + ip + "\n"
+                    "    Port           : 14550\n\n"
+                    "  Press Enter to return.";
+                ctx.state = State::SubMenu;
+                render(ctx);
+                break;
+            }
+            case 2: {
+                ctx.state = State::Monitoring;
+                ctx.telemetry_snap = std::make_shared<TelemetrySnapshot>();
+                ctx.telemetry_plugin = std::make_unique<Telemetry>(ctx.system);
+                setup_monitoring(
+                    static_cast<Telemetry&>(*ctx.telemetry_plugin),
+                    ctx.telemetry_snap,
+                    [&ctx]() {
+                        boost::asio::post(ctx.io, [&ctx]() { request_render(ctx); });
+                    }
+                );
+                render(ctx);
+                break;
+            }
+            default:
+                render(ctx);
+        }
+    } else {
+        ctx.telemetry_plugin = nullptr;
+        ctx.state = State::MainMenu;
+        render(ctx);
+    }
+}
+
+// ── Input polling ─────────────────────────────────────────────────────────────
+
+static void start_input_poll(AppContext& ctx) {
+    ctx.input_timer.expires_after(std::chrono::milliseconds(33));
+    ctx.input_timer.async_wait([&ctx](const boost::system::error_code& ec) {
+        if (ec || ctx.io.stopped()) return;
+
+        int ch;
+        bool dirty = false;
+        while ((ch = getch()) != ERR) {
+            if (ch == KEY_RESIZE) {
+                render(ctx);
+                dirty = false;
+            } else if (ch == '\n' || ch == KEY_ENTER) {
+                std::string cmd = ctx.input_line;
+                ctx.input_line.clear();
+                process_command(ctx, cmd);
+                dirty = false;
+            } else if (ch == KEY_BACKSPACE || ch == 127 || ch == 8) {
+                if (!ctx.input_line.empty()) {
+                    ctx.input_line.pop_back();
+                    dirty = true;
+                }
+            } else if (ch >= 32 && ch < 127) {
+                ctx.input_line += (char)ch;
+                dirty = true;
+            }
+        }
+
+        if (dirty) {
+            int rows = getmaxy(stdscr);
+            mvprintw(rows - 1, 0, "> %-*s", getmaxx(stdscr) - 2, ctx.input_line.c_str());
+            move(rows - 1, 2 + (int)ctx.input_line.size());
+            refresh();
+        }
+
+        start_input_poll(ctx);
+    });
+}
+
+// ── QGC watchdog ──────────────────────────────────────────────────────────────
+
+static void start_qgc_watchdog(AppContext& ctx) {
+    ctx.qgc_watchdog.expires_after(std::chrono::seconds(1));
+    ctx.qgc_watchdog.async_wait([&ctx](const boost::system::error_code& ec) {
+        if (ec || ctx.io.stopped()) return;
+
+        bool found = false;
+        for (auto& sys : ctx.sdk.systems()) {
+            if (!sys->has_autopilot() && sys->is_connected()) { found = true; break; }
+        }
+
+        if (found != ctx.qgc_connected) {
+            ctx.qgc_connected = found;
+            request_render(ctx);
+        }
+
+        start_qgc_watchdog(ctx);
+    });
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
 
 int main() {
+    mavsdk::log::subscribe([](mavsdk::log::Level, const std::string&, const std::string&, int) {
+        return true; // suppress all MAVSDK output — ncurses owns the terminal
+    });
+
+    auto config = try_load_config();
+    const std::string serial_device = config.count("serial_device") ? config.at("serial_device") : "/dev/ttyACM0";
+    const int serial_baud = config.count("serial_baud") ? std::stoi(config.at("serial_baud")) : 57600;
+
+    if (start_mavlink_router(serial_device, serial_baud) < 0)
+        std::cerr << "Warning: MAVLink router failed to start.\n";
+
     Mavsdk sdk{Mavsdk::Configuration{ComponentType::CompanionComputer}};
-    const std::string connection_url = "serial:///dev/ttyACM0:57600";
-    ConnectionResult connection_result = sdk.add_any_connection(connection_url);
-    if (connection_result != ConnectionResult::Success) {
-        std::cerr << "Connection failed: " << connection_result << std::endl;
+    if (sdk.add_any_connection("udpin://0.0.0.0:14551") != ConnectionResult::Success) {
+        std::cerr << "Connection failed.\n";
         return -1;
     }
 
-    std::cout << "Waiting for a drone to connect..." << std::endl;
-    auto prom{std::make_shared<std::promise<std::shared_ptr<System>>>()};
-    auto fut{prom->get_future()};
-    sdk.subscribe_on_new_system([&sdk, prom]() {
-        std::shared_ptr<System> system = sdk.systems().at(0);
-        std::cout << "Drone discovered!" << std::endl;
-        prom->set_value(system);
+    // Wait for drone (before ncurses so we can print normally)
+    std::cout << "Waiting for drone..." << std::flush;
+    auto prom = std::make_shared<std::promise<std::shared_ptr<System>>>();
+    auto fut = prom->get_future();
+    auto promise_set = std::make_shared<std::atomic<bool>>(false);
+    sdk.subscribe_on_new_system([&sdk, prom, promise_set]() {
+        for (auto& sys : sdk.systems())
+            if (sys->has_autopilot() && !promise_set->exchange(true))
+                prom->set_value(sys);
     });
     std::shared_ptr<System> system{fut.get()};
+    std::cout << " connected.\n" << std::flush;
 
-    AppContext ctx(system);
+    // Init ncurses
+    initscr();
+    cbreak();
+    noecho();
+    keypad(stdscr, TRUE);
+    nodelay(stdscr, TRUE);
+    curs_set(1);
+    start_color();
+    use_default_colors();
+    init_pair(1, COLOR_GREEN,  -1);  // QGC connected
+    init_pair(2, COLOR_YELLOW, -1);  // QGC waiting
+
+    AppContext ctx(sdk, system);
 
     ctx.signals.async_wait([&ctx](const boost::system::error_code&, int) {
-        std::cout << "\nCtrl+C detected. Shutting down." << std::endl;
-        ctx.io_context.stop();
+        endwin();
+        ctx.io.stop();
     });
 
-    display_main_menu();
-    start_reading_input(ctx);
-    ctx.io_context.run();
-}
+    render(ctx);
+    start_input_poll(ctx);
+    start_qgc_watchdog(ctx);
+    ctx.io.run();
 
-void start_reading_input(AppContext &ctx) {
-    boost::asio::async_read_until(
-        ctx.input,
-        ctx.buffer,
-        '\n',
-        boost::bind(on_input_received, std::ref(ctx), boost::asio::placeholders::error)
-    );
-}
-
-void on_input_received(AppContext &ctx, const boost::system::error_code &error) {
-    if (error) {
-        if (error != boost::asio::error::eof) {
-            std::cerr << "Input error: " << error.message() << std::endl;
-        }
-        ctx.io_context.stop();
-        return;
-    }
-
-    std::istream is(&ctx.buffer);
-    std::string command;
-    std::getline(is, command);
-
-    process_command(ctx, command);
-
-    if (!ctx.io_context.stopped()) {
-        start_reading_input(ctx);
-    }
-}
-
-void process_command(AppContext &ctx, const std::string &command) {
-    if (ctx.current_state == AppContext::MainMenu) {
-        short choice = 0;
-        try {
-            choice = std::stoi(command);
-        } catch (...) {
-            std::cout << "Invalid input. Please enter a number.\n\n";
-            display_main_menu();
-            return;
-        }
-
-        switch (choice) {
-            case 1:
-                ctx.current_state = AppContext::NotMainMenu;
-                std::cout 
-                    << "\n" << std::string(50, '-')
-                    << "\nINSTRUCTIONS:"
-                    << "\n 1. Configure the drone and its joystick controls via QGroundControl."
-                    << "\n 2. Start SLAM pipeline."
-                    << "\n\nPress Enter to return to the main menu."
-                    << "\n" << std::string(50, '-') << "\n> " << std::flush;
-                break;
-            case 2:
-                start_monitoring(ctx);
-                break;
-            default:
-                std::cout << "Invalid choice.\n";
-                display_main_menu();
-                break;
-        }
-    } else if (ctx.current_state == AppContext::NotMainMenu) {
-        std::cout << "\nReturning to main menu.\n";
-        ctx.pointer = nullptr;
-        ctx.current_state = AppContext::MainMenu;
-        display_main_menu();
-    }
-}
-
-void display_main_menu() {
-    std::cout
-        << "\n" << std::string(60, '_') << "\n"
-        << std::string(25, ' ') << "Main Menu\n"
-        << std::string(60, '_')
-        << "\nWelcome to the main menu. At any time, press Ctrl+C to exit."
-        << "\nEnter your selection:\n\n"
-        << " 1. Read instructions\n"
-        << " 2. Start telemetry monitoring\n"
-        << std::string(60, '_') << "\n> " << std::flush;
-}
-
-void start_monitoring(AppContext &ctx) {
-    ctx.current_state = AppContext::NotMainMenu;
-    ctx.pointer = std::make_unique<Telemetry>(ctx.system);
-    setup_monitoring(static_cast<mavsdk::Telemetry&>(*ctx.pointer)); 
-
-    std::cout << "\n" << std::string(50, '-')
-              << "\nTelemetry monitoring started. MAVSDK is printing updates."
-              << "\nPress Enter to return to the main menu."
-              << "\n" << std::string(50, '-') << "\n> " << std::flush;
+    endwin();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,8 +11,6 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
-// Boost before ncurses — ncurses defines macros (timeout, clear, move…)
-// that conflict with Boost ASIO if included first
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/system.h>
 #include <mavsdk/plugins/telemetry/telemetry.h>
@@ -339,7 +337,7 @@ static void start_qgc_watchdog(AppContext& ctx) {
 
 int main() {
     mavsdk::log::subscribe([](mavsdk::log::Level, const std::string&, const std::string&, int) {
-        return true; // suppress all MAVSDK output — ncurses owns the terminal
+        return true;
     });
 
     auto config = try_load_config();
@@ -355,7 +353,6 @@ int main() {
         return -1;
     }
 
-    // Wait for drone (before ncurses so we can print normally)
     std::cout << "Waiting for drone..." << std::flush;
     auto prom = std::make_shared<std::promise<std::shared_ptr<System>>>();
     auto fut = prom->get_future();
@@ -368,7 +365,6 @@ int main() {
     std::shared_ptr<System> system{fut.get()};
     std::cout << " connected.\n" << std::flush;
 
-    // Init ncurses
     initscr();
     cbreak();
     noecho();
@@ -377,8 +373,8 @@ int main() {
     curs_set(1);
     start_color();
     use_default_colors();
-    init_pair(1, COLOR_GREEN,  -1);  // QGC connected
-    init_pair(2, COLOR_YELLOW, -1);  // QGC waiting
+    init_pair(1, COLOR_GREEN,  -1);
+    init_pair(2, COLOR_YELLOW, -1);
 
     AppContext ctx(sdk, system);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,10 +173,10 @@ static void render(const AppContext& ctx) {
 
         // Power
         attron(A_BOLD); mvprintw(r++, 2, "Power"); attroff(A_BOLD);
-        if (s.battery_pct >= 0)
+        if (s.has_battery)
             mvprintw(r++, 4, "Battery     : %d%%  (%.1f V)", s.battery_pct, s.battery_v);
         else
-            mvprintw(r++, 4, "Battery     : —");
+            mvprintw(r++, 4, "Battery     : N/A");
         r++;
 
         // Position

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -32,8 +32,11 @@ void setup_monitoring(Telemetry& telemetry,
     });
 
     telemetry.subscribe_battery([snap, on_update](Telemetry::Battery b) {
-        snap->battery_pct = static_cast<int>(b.remaining_percent);
-        snap->battery_v   = b.voltage_v;
+        snap->has_battery = b.remaining_percent >= 0;
+        if (snap->has_battery) {
+            snap->battery_pct = static_cast<int>(b.remaining_percent);
+            snap->battery_v   = b.voltage_v;
+        }
         on_update();
     });
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -1,32 +1,61 @@
 #include "monitor.hpp"
-
-#include <iostream>
-
 #include <mavsdk/plugins/telemetry/telemetry.h>
+#include <cmath>
 
 using namespace mavsdk;
 
-static std::string flight_mode_to_str(Telemetry::FlightMode mode) {
-    switch (mode) {
-        case Telemetry::FlightMode::Unknown:        return "Unknown";
+static std::string flight_mode_str(Telemetry::FlightMode m) {
+    switch (m) {
         case Telemetry::FlightMode::Ready:          return "Ready";
         case Telemetry::FlightMode::Takeoff:        return "Takeoff";
         case Telemetry::FlightMode::Hold:           return "Hold";
         case Telemetry::FlightMode::Mission:        return "Mission";
-        case Telemetry::FlightMode::ReturnToLaunch: return "ReturnToLaunch";
+        case Telemetry::FlightMode::ReturnToLaunch: return "Return to Launch";
         case Telemetry::FlightMode::Land:           return "Land";
         case Telemetry::FlightMode::Offboard:       return "Offboard";
-        case Telemetry::FlightMode::FollowMe:       return "FollowMe";
-        default:                                    return "Other";
+        case Telemetry::FlightMode::FollowMe:       return "Follow Me";
+        default:                                    return "Unknown";
     }
 }
 
-void setup_monitoring(Telemetry &telemetry) {
-    telemetry.subscribe_flight_mode([](Telemetry::FlightMode flight_mode) {
-        std::cout << "Flight Mode: " << flight_mode_to_str(flight_mode) << std::endl;
+void setup_monitoring(Telemetry& telemetry,
+                      std::shared_ptr<TelemetrySnapshot> snap,
+                      std::function<void()> on_update) {
+    telemetry.subscribe_armed([snap, on_update](bool armed) {
+        snap->armed = armed;
+        on_update();
     });
 
-    telemetry.subscribe_battery([](Telemetry::Battery battery) {
-        std::cout << "Battery: " << battery.remaining_percent << " %" << std::endl;
+    telemetry.subscribe_flight_mode([snap, on_update](Telemetry::FlightMode m) {
+        snap->flight_mode = flight_mode_str(m);
+        on_update();
+    });
+
+    telemetry.subscribe_battery([snap, on_update](Telemetry::Battery b) {
+        snap->battery_pct = static_cast<int>(b.remaining_percent);
+        snap->battery_v   = b.voltage_v;
+        on_update();
+    });
+
+    telemetry.subscribe_position([snap, on_update](Telemetry::Position p) {
+        snap->latitude   = p.latitude_deg;
+        snap->longitude  = p.longitude_deg;
+        snap->abs_alt_m  = p.absolute_altitude_m;
+        snap->rel_alt_m  = p.relative_altitude_m;
+        snap->has_fix    = true;
+        on_update();
+    });
+
+    telemetry.subscribe_attitude_euler([snap, on_update](Telemetry::EulerAngle a) {
+        snap->roll_deg  = a.roll_deg;
+        snap->pitch_deg = a.pitch_deg;
+        snap->yaw_deg   = a.yaw_deg;
+        on_update();
+    });
+
+    telemetry.subscribe_velocity_ned([snap, on_update](Telemetry::VelocityNed v) {
+        snap->ground_spd = std::sqrt(v.north_m_s * v.north_m_s +
+                                     v.east_m_s  * v.east_m_s);
+        on_update();
     });
 }

--- a/src/qgc_bridge.cpp
+++ b/src/qgc_bridge.cpp
@@ -1,0 +1,41 @@
+#include "qgc_bridge.hpp"
+
+#include <unistd.h>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+
+pid_t start_mavlink_router(const std::string& serial_device, int baud) {
+    const std::string config_path = "/tmp/orbis-mlr.conf";
+    {
+        std::ofstream f(config_path);
+        if (!f.is_open()) {
+            std::cerr << "Failed to write mavlink-router config.\n";
+            return -1;
+        }
+        f << "[General]\nTcpServerPort=0\n\n"
+          << "[UartEndpoint Pixhawk]\nDevice=" << serial_device << "\nBaud=" << baud << "\n\n"
+          << "[UdpEndpoint QGC]\nMode=Server\nAddress=0.0.0.0\nPort=14550\n\n"
+          << "[UdpEndpoint MAVSDK]\nMode=Normal\nAddress=127.0.0.1\nPort=14551\n";
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        std::cerr << "fork() failed — mavlink-router not started.\n";
+        return -1;
+    }
+    if (pid == 0) {
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDOUT_FILENO);
+            dup2(devnull, STDERR_FILENO);
+            close(devnull);
+        }
+        execl("/usr/local/bin/mavlink-routerd", "mavlink-routerd",
+              "-c", config_path.c_str(), nullptr);
+        _exit(1);
+    }
+
+    std::cout << "MAVLink router started.\n";
+    return pid;
+}


### PR DESCRIPTION
## What's New
  - QGroundControl wireless support via mavlink-router, routing MAVLink from the flight controller over UDP to both QGC and MAVSDK simultaneously.
  - Live ncurses TUI replacing scrolling terminal output, with a persistent header showing real-time QGC connection status.
  - An update to telemetry monitor (armed state, flight mode, battery, GPS, attitude, ground speed), and rate-limited 30fps rendering. 
  - MAVSDK and mavlink-router versions pinned. 
  - Full README rewrite covering requirements, architecture, MAVLink routing diagram, and QGC setup guide.