### PR TITLE
feat/gcs-migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,17 @@
-FROM arm64v8/debian:12-slim
+FROM debian:13-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG MAVSDK_VERSION=3.17.0
-ARG MLR_VERSION=v4
 
 RUN apt-get update && apt-get install -y \
     wget cmake build-essential \
-    git meson ninja-build pkg-config \
     libboost-all-dev libncurses-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && printf 'Name: systemd\nDescription: systemd\nVersion: 9\nLibs: -lsystemd\nCflags: -I/usr/include/systemd\nsystemdsystemunitdir=/lib/systemd/system\nsystemduserunitdir=/lib/systemd/user\n' \
-       > /usr/lib/pkgconfig/systemd.pc
+    && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/mavlink/MAVSDK/releases/download/v${MAVSDK_VERSION}/libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb && \
-    apt-get install -y ./libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb && \
-    rm libmavsdk-dev_${MAVSDK_VERSION}_debian12_arm64.deb
-
-RUN git clone --recurse-submodules --shallow-submodules --branch ${MLR_VERSION} \
-        https://github.com/mavlink-router/mavlink-router.git /tmp/mlr \
-    && cd /tmp/mlr && meson setup build && ninja -C build \
-    && cp build/src/mavlink-routerd /usr/local/bin/ \
-    && rm -rf /tmp/mlr
+RUN wget https://github.com/mavlink/MAVSDK/releases/download/v${MAVSDK_VERSION}/libmavsdk-dev_${MAVSDK_VERSION}_debian13_amd64.deb && \
+    apt-get install -y ./libmavsdk-dev_${MAVSDK_VERSION}_debian13_amd64.deb && \
+    rm libmavsdk-dev_${MAVSDK_VERSION}_debian13_amd64.deb
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,20 @@ ARG MAVSDK_VERSION=3.17.0
 RUN apt-get update && apt-get install -y \
     wget cmake build-essential \
     libboost-all-dev libncurses-dev \
+    ca-certificates curl gnupg openssh-client \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian trixie stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update && apt-get install -y docker-ce-cli docker-compose-plugin \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://github.com/mavlink/MAVSDK/releases/download/v${MAVSDK_VERSION}/libmavsdk-dev_${MAVSDK_VERSION}_debian13_amd64.deb && \
     apt-get install -y ./libmavsdk-dev_${MAVSDK_VERSION}_debian13_amd64.deb && \
     rm libmavsdk-dev_${MAVSDK_VERSION}_debian13_amd64.deb
+
+RUN echo "StrictHostKeyChecking accept-new" >> /etc/ssh/ssh_config
 
 WORKDIR /workspace
 
@@ -21,4 +30,6 @@ RUN mkdir build && cd build && \
     cmake .. && \
     make
 
-ENTRYPOINT ["/workspace/build/orbis"]
+RUN chmod +x /workspace/docker-entrypoint.sh
+
+ENTRYPOINT ["/workspace/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,96 +1,71 @@
 # Orbis
-An autonomous drone that maps and navigates its environment using SLAM.
+An autonomous indoor drone that responds to natural language voice commands.
 
 ---
 
-## Requirements
+## Setup
 
-### Hardware
-- **Drone side:** Any ARM64 onboard computer acting as a MAVLink bridge, with any MAVLink-compatible flight controller connected via serial
-- **Ground station:** Any machine capable of running Orbis and QGroundControl, networked to the drone
+### Requirements
 
-### Software
+**Hardware**
+- MAVLink-compatible flight controller
+- Companion computer with serial connection to flight controller
+- Depth sensor
+- Ubuntu x86_64 ground station
+
+**Ground station software**
 - Docker with Compose v2
-- QGroundControl
+- SSH key configured to companion computer
 
----
+**Companion computer software**
+- Docker with Compose v2
+- SSH server enabled
 
-## Configuration
-Edit `common/config.yaml` before building:
+**Optional**
+- QGroundControl *(manual control and parameter tuning during development)*
+
+### Configuration
+
+Edit `common/config.yaml`:
 ```yaml
-serial_device: /dev/ttyACM0  # serial device path to the flight controller
-serial_baud: 57600           # baud rate of the serial connection
+serial_device: /dev/ttyACM0       # serial port to flight controller (companion computer side)
+serial_baud: 57600                # baud rate of the serial connection
+drone_host: user@companion.local  # SSH connection to companion computer
 ```
 
----
+### Build
 
-## Commands
-
-**Build:**
 ```bash
-docker compose build orbis
+docker compose build
 ```
 
-**Run** (interactive, removed on exit):
+### Deploy relay
+
+On first run, deploy the MAVLink relay to the companion computer from the Orbis menu:
+
+```
+1. Start relay
+```
+
+This uses Docker's remote daemon over SSH. After the first deploy, the relay auto-starts on every reboot.
+
+### Run
+
 ```bash
 docker compose run --rm orbis
 ```
 
-**Stop and remove containers:**
-```bash
-docker compose down --remove-orphans
-```
-
-**Nuke all unused Docker resources:**
-```bash
-docker system prune -a --volumes
-```
-
-**Force-kill all running containers:**
-```bash
-docker kill $(docker ps -q)
-```
-
----
-
-## QGroundControl
-
-1. Make sure Orbis is running on the ground station and the drone is powered on.
-2. In QGroundControl: **Application Settings → Comm Links → Add → UDP**.
-3. Set the server address to the drone-side bridge computer's IP and port **14550**.
-4. Click Connect — QGC will link up and the header bar in Orbis will turn green.
-
 ---
 
 ## Architecture
-
-> This section documents how the system is built. It will grow as the project expands.
-
-### Stack
-
-| Component | Version | Role |
-|---|---|---|
-| Debian slim | 12 (Bookworm) | Base Docker image (`arm64v8`) |
-| MAVSDK | 3.17.0 | High-level MAVLink SDK — telemetry, commands |
-| mavlink-router | v4 | Low-level MAVLink packet forwarder |
-| Boost.Asio | system | Async event loop, timers, signal handling |
-| ncurses | system | Terminal UI |
-
----
-
-### MAVLink routing
-
-The flight controller speaks MAVLink over a serial connection. Two consumers need that stream simultaneously — MAVSDK (for telemetry and control) and QGroundControl (for full ground station visibility). A single serial port can only be opened once, so **mavlink-router** acts as a transparent byte-level forwarder.
-
-The Pi runs only mavlink-router — it is a dumb MAVLink bridge. All application logic (Orbis, QGC, and eventually SLAM) runs on the ground station.
 
 ```
 [ Drone ]
   Flight controller
         │ serial
         ▼
-  Pi — mavlink-router
-        │ UDP (network)
+  Companion computer — mavlink-router (relay container)
+        │ UDP over WiFi
         ▼
 [ Ground station ]
   ┌─────┴──────┐
@@ -99,11 +74,28 @@ The Pi runs only mavlink-router — it is a dumb MAVLink bridge. All application
  QGC         MAVSDK (Orbis)
 ```
 
----
+The companion computer is a dumb MAVLink bridge. All logic — telemetry, commands, SLAM, AI — runs on the ground station.
 
-### MAVSDK
+### Stack
 
-MAVSDK connects to mavlink-router's output on `udpin://0.0.0.0:14551`. It is configured as a `CompanionComputer` (not a GCS), which keeps it from interfering with QGC's GCS role.
+| Component | Version | Runs on | Role |
+|---|---|---|---|
+| Debian slim | 13 (Trixie) | Ground station (amd64) | Base image for Orbis |
+| Debian slim | 13 (Trixie) | Companion computer (native arch) | Base image for relay |
+| MAVSDK | 3.17.0 | Ground station | High-level MAVLink SDK |
+| mavlink-router | v4 | Companion computer | MAVLink packet forwarder |
+| Boost.Asio | system | Ground station | Async event loop |
+| ncurses | system | Ground station | Terminal UI |
+
+### Relay deployment
+
+The `relay/` directory contains the relay's Dockerfile and entrypoint. When you select **Start relay** in the Orbis menu, it runs:
+
+```bash
+DOCKER_HOST=ssh://<drone_host> docker compose -f relay/docker-compose.yaml up -d --build
+```
+
+Docker streams the `relay/` build context over SSH to the companion computer's daemon, which builds and starts the container natively. The companion computer never needs the repo cloned. `restart: unless-stopped` keeps the relay running across reboots.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ serial_baud: 57600                # baud rate of the serial connection
 drone_host: user@companion.local  # SSH connection to companion computer
 ```
 
+### SSH key setup
+
+Orbis deploys the relay over SSH. Run once from the ground station:
+
+```bash
+ssh-keygen -t ed25519 -C "orbis"   # skip if you already have a key
+ssh-copy-id user@companion.local   # use the drone_host value from config.yaml
+```
+
 ### Build
 
 ```bash

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,2 +1,3 @@
 serial_device: /dev/ttyACM0
 serial_baud: 57600
+drone_host: orbis@drone.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,3 +5,4 @@ services:
     network_mode: host
     volumes:
       - ./common:/workspace/common:ro
+      - ~/.ssh:/mnt/ssh:ro

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   orbis:
     build: .
-    container_name: "orbis_container"
+    container_name: orbis
     network_mode: host
-    devices:
-      - "/dev/ttyACM0:/dev/ttyACM0"
+    volumes:
+      - ./common:/workspace/common:ro

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# SSH files mounted from Windows have incorrect permissions.
+# Copy to a fresh directory with correct Unix permissions before the SSH client sees them.
+if [ -d /mnt/ssh ]; then
+    mkdir -p /root/.ssh
+    cp -r /mnt/ssh/. /root/.ssh/
+    chmod 700 /root/.ssh
+    find /root/.ssh -type f -exec chmod 600 {} \;
+    find /root/.ssh -name "*.pub" -exec chmod 644 {} \;
+fi
+
+exec /workspace/build/orbis "$@"

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:13-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG MLR_VERSION=v4
+
+RUN apt-get update && apt-get install -y \
+    git meson ninja-build pkg-config build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && printf 'Name: systemd\nDescription: systemd\nVersion: 9\nLibs: -lsystemd\nCflags: -I/usr/include/systemd\nsystemdsystemunitdir=/lib/systemd/system\nsystemduserunitdir=/lib/systemd/user\n' \
+       > /usr/lib/pkgconfig/systemd.pc
+
+RUN git clone --recurse-submodules --shallow-submodules --branch ${MLR_VERSION} \
+        https://github.com/mavlink-router/mavlink-router.git /tmp/mlr \
+    && cd /tmp/mlr && meson setup build && ninja -C build \
+    && cp build/src/mavlink-routerd /usr/local/bin/ \
+    && rm -rf /tmp/mlr
+
+COPY start-relay.sh /start-relay.sh
+RUN chmod +x /start-relay.sh
+
+ENTRYPOINT ["/start-relay.sh"]

--- a/relay/docker-compose.yaml
+++ b/relay/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  relay:
+    build: .
+    container_name: orbis-relay
+    network_mode: host
+    restart: unless-stopped
+    devices:
+      - /dev/ttyACM0:/dev/ttyACM0
+    environment:
+      - SERIAL_DEVICE=/dev/ttyACM0
+      - SERIAL_BAUD=57600

--- a/relay/start-relay.sh
+++ b/relay/start-relay.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+SERIAL_DEVICE="${SERIAL_DEVICE:-/dev/ttyACM0}"
+SERIAL_BAUD="${SERIAL_BAUD:-57600}"
+CONFIG="/tmp/orbis-mlr.conf"
+
+cat > "$CONFIG" <<EOF
+[General]
+TcpServerPort=0
+
+[UartEndpoint Pixhawk]
+Device=$SERIAL_DEVICE
+Baud=$SERIAL_BAUD
+
+[UdpEndpoint QGC]
+Mode=Server
+Address=0.0.0.0
+Port=14550
+
+[UdpEndpoint MAVSDK]
+Mode=Server
+Address=0.0.0.0
+Port=14551
+EOF
+
+exec mavlink-routerd -c "$CONFIG"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include <mavsdk/plugins/telemetry/telemetry.h>
 #include <mavsdk/log_callback.h>
 #include <boost/asio.hpp>
+#include <boost/process.hpp>
 
 #include <ncurses.h>
 
@@ -93,8 +94,10 @@ struct AppContext {
 
     State        state         = State::MainMenu;
     bool         qgc_connected = false;
+    bool         relay_active  = false;
     std::string  input_line;
     std::string  sub_content;
+    std::string  drone_host;
     std::shared_ptr<TelemetrySnapshot> telemetry_snap = std::make_shared<TelemetrySnapshot>();
 
     AppContext(Mavsdk& sdk, std::shared_ptr<System> system)
@@ -117,14 +120,30 @@ static void draw_header(const AppContext& ctx) {
 
     mvprintw(1, 2, "ORBIS");
 
-    std::string label = "QGC: ";
-    std::string status = ctx.qgc_connected ? "Connected" : "Waiting...";
-    int right_col = cols - (int)(label.size() + status.size()) - 2;
-    mvprintw(1, right_col, "%s", label.c_str());
+    std::string qgc_label  = "QGC: ";
+    std::string qgc_status = ctx.qgc_connected ? "Connected" : "Waiting...";
+
+    int right = cols - (int)(qgc_label.size() + qgc_status.size()) - 2;
+    mvprintw(1, right, "%s", qgc_label.c_str());
     if (ctx.qgc_connected) attron(COLOR_PAIR(1) | A_BOLD);
     else                   attron(COLOR_PAIR(2));
-    printw("%s", status.c_str());
+    printw("%s", qgc_status.c_str());
     attroff(COLOR_PAIR(1) | COLOR_PAIR(2) | A_BOLD);
+
+    if (!ctx.drone_host.empty()) {
+        bool heartbeat = ctx.system && ctx.system->is_connected();
+        std::string relay_label  = "Relay: ";
+        std::string relay_status = !ctx.relay_active    ? "Stopped"
+                                 : heartbeat            ? "Active"
+                                                        : "No Heartbeat";
+        int relay_col = right - (int)(relay_label.size() + relay_status.size()) - 3;
+        mvprintw(1, relay_col, "%s", relay_label.c_str());
+        if (!ctx.relay_active)       attron(COLOR_PAIR(2));
+        else if (heartbeat)          attron(COLOR_PAIR(1) | A_BOLD);
+        else                         attron(COLOR_PAIR(3) | A_BOLD);
+        printw("%s", relay_status.c_str());
+        attroff(COLOR_PAIR(1) | COLOR_PAIR(2) | COLOR_PAIR(3) | A_BOLD);
+    }
 
     attron(A_BOLD);
     mvhline(2, 0, '=', cols);
@@ -147,8 +166,9 @@ static void render(const AppContext& ctx) {
     draw_header(ctx);
 
     if (ctx.state == State::MainMenu) {
-        mvprintw(4, 2, "1. QGroundControl");
-        mvprintw(5, 2, "2. Telemetry monitor");
+        mvprintw(4, 2, ctx.relay_active ? "1. Stop relay" : "1. Start relay");
+        mvprintw(5, 2, "2. QGroundControl setup");
+        mvprintw(6, 2, "3. Live telemetry monitor");
         attron(A_DIM);
         mvhline(rows - 3, 0, '-', cols);
         mvprintw(rows - 2, 2, "Ctrl+C to exit");
@@ -236,10 +256,41 @@ static void process_command(AppContext& ctx, const std::string& cmd) {
 
         switch (choice) {
             case 1: {
-                std::string ip = get_local_ip();
+                if (ctx.drone_host.empty()) {
+                    ctx.sub_content =
+                        "  RELAY\n\n"
+                        "  drone_host not set in config.yaml.\n\n"
+                        "  Press Enter to return.";
+                    ctx.state = State::SubMenu;
+                    render(ctx);
+                    break;
+                }
+                bool stopping = ctx.relay_active;
+                std::string cmd = "DOCKER_HOST=ssh://" + ctx.drone_host +
+                    (stopping
+                        ? " docker compose -f relay/docker-compose.yaml down"
+                        : " docker compose -f relay/docker-compose.yaml up -d --build");
+                ctx.sub_content = stopping
+                    ? "  STOP RELAY\n\n  Stopping...\n\n"
+                    : "  START RELAY\n\n  Deploying — this may take a few minutes on first run...\n\n";
+                ctx.state = State::SubMenu;
+                render(ctx);
+                int rc = std::system(cmd.c_str());
+                if (rc == 0) ctx.relay_active = !stopping;
+                ctx.sub_content += rc == 0
+                    ? (stopping ? "  Relay stopped." : "  Relay running.")
+                    : "  Failed (exit " + std::to_string(rc) + ").\n"
+                      "  Ensure companion computer has Docker running and SSH key is configured.";
+                ctx.sub_content += "\n\n  Press Enter to return.";
+                render(ctx);
+                break;
+            }
+            case 2: {
+                std::string host = ctx.drone_host.empty() ? get_local_ip() : ctx.drone_host.substr(ctx.drone_host.find('@') != std::string::npos ? ctx.drone_host.find('@') + 1 : 0);
+                std::string ip = host;
                 ctx.sub_content =
-                    "  QGROUNDCONTROL\n\n"
-                    "  Connect QGC on your laptop:\n"
+                    "  QGROUNDCONTROL SETUP\n\n"
+                    "  Connect QGC:\n"
                     "    Comm Links -> Add -> UDP\n"
                     "    Server address : " + ip + "\n"
                     "    Port           : 14550\n\n"
@@ -248,7 +299,7 @@ static void process_command(AppContext& ctx, const std::string& cmd) {
                 render(ctx);
                 break;
             }
-            case 2: {
+            case 3: {
                 ctx.state = State::Monitoring;
                 ctx.telemetry_snap = std::make_shared<TelemetrySnapshot>();
                 ctx.telemetry_plugin = std::make_unique<Telemetry>(ctx.system);
@@ -312,6 +363,22 @@ static void start_input_poll(AppContext& ctx) {
     });
 }
 
+// ── Relay status (one-shot on startup) ───────────────────────────────────────
+
+static void check_relay_once(AppContext& ctx) {
+    if (ctx.drone_host.empty()) return;
+    std::string cmd = "DOCKER_HOST=ssh://" + ctx.drone_host +
+        " docker ps -q --filter name=orbis-relay | grep -q .";
+    boost::process::async_system(
+        ctx.io,
+        [&ctx](boost::system::error_code, int exit_code) {
+            ctx.relay_active = (exit_code == 0);
+            request_render(ctx);
+        },
+        boost::process::shell, cmd
+    );
+}
+
 // ── QGC watchdog ──────────────────────────────────────────────────────────────
 
 static void start_qgc_watchdog(AppContext& ctx) {
@@ -342,13 +409,23 @@ int main() {
 
     auto config = try_load_config();
     const std::string serial_device = config.count("serial_device") ? config.at("serial_device") : "/dev/ttyACM0";
-    const int serial_baud = config.count("serial_baud") ? std::stoi(config.at("serial_baud")) : 57600;
+    const int         serial_baud   = config.count("serial_baud")   ? std::stoi(config.at("serial_baud")) : 57600;
+    const std::string drone_host    = config.count("drone_host")    ? config.at("drone_host") : "";
+    const std::string drone_hostname = drone_host.find('@') != std::string::npos
+        ? drone_host.substr(drone_host.find('@') + 1)
+        : drone_host;
 
-    if (start_mavlink_router(serial_device, serial_baud) < 0)
-        std::cerr << "Warning: MAVLink router failed to start.\n";
+    if (drone_host.empty()) {
+        if (start_mavlink_router(serial_device, serial_baud) < 0)
+            std::cerr << "Warning: MAVLink router failed to start.\n";
+    }
+
+    const std::string connection = drone_host.empty()
+        ? "udpin://0.0.0.0:14551"
+        : "udpout://" + drone_hostname + ":14551";
 
     Mavsdk sdk{Mavsdk::Configuration{ComponentType::CompanionComputer}};
-    if (sdk.add_any_connection("udpin://0.0.0.0:14551") != ConnectionResult::Success) {
+    if (sdk.add_any_connection(connection) != ConnectionResult::Success) {
         std::cerr << "Connection failed.\n";
         return -1;
     }
@@ -375,14 +452,17 @@ int main() {
     use_default_colors();
     init_pair(1, COLOR_GREEN,  -1);
     init_pair(2, COLOR_YELLOW, -1);
+    init_pair(3, COLOR_RED,    -1);
 
     AppContext ctx(sdk, system);
+    ctx.drone_host = drone_host;
 
     ctx.signals.async_wait([&ctx](const boost::system::error_code&, int) {
         endwin();
         ctx.io.stop();
     });
 
+    check_relay_once(ctx);
     render(ctx);
     start_input_poll(ctx);
     start_qgc_watchdog(ctx);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,6 +94,7 @@ struct AppContext {
 
     State        state         = State::MainMenu;
     bool         qgc_connected = false;
+    int          qgc_miss_count = 0;
     bool         relay_active  = false;
     std::string  input_line;
     std::string  sub_content;
@@ -121,7 +122,7 @@ static void draw_header(const AppContext& ctx) {
     mvprintw(1, 2, "ORBIS");
 
     std::string qgc_label  = "QGC: ";
-    std::string qgc_status = ctx.qgc_connected ? "Connected" : "Waiting...";
+    std::string qgc_status = ctx.qgc_connected ? "Connected" : "Disconnected";
 
     int right = cols - (int)(qgc_label.size() + qgc_status.size()) - 2;
     mvprintw(1, right, "%s", qgc_label.c_str());
@@ -269,20 +270,26 @@ static void process_command(AppContext& ctx, const std::string& cmd) {
                 std::string cmd = "DOCKER_HOST=ssh://" + ctx.drone_host +
                     (stopping
                         ? " docker compose -f relay/docker-compose.yaml down"
-                        : " docker compose -f relay/docker-compose.yaml up -d --build");
+                        : " docker compose -f relay/docker-compose.yaml up -d --build") +
+                    " >/dev/null 2>&1";
                 ctx.sub_content = stopping
                     ? "  STOP RELAY\n\n  Stopping...\n\n"
-                    : "  START RELAY\n\n  Deploying — this may take a few minutes on first run...\n\n";
+                    : "  START RELAY\n\n  Deploying - this may take a few minutes on first run...\n\n";
                 ctx.state = State::SubMenu;
                 render(ctx);
-                int rc = std::system(cmd.c_str());
-                if (rc == 0) ctx.relay_active = !stopping;
-                ctx.sub_content += rc == 0
-                    ? (stopping ? "  Relay stopped." : "  Relay running.")
-                    : "  Failed (exit " + std::to_string(rc) + ").\n"
-                      "  Ensure companion computer has Docker running and SSH key is configured.";
-                ctx.sub_content += "\n\n  Press Enter to return.";
-                render(ctx);
+                boost::process::async_system(
+                    ctx.io,
+                    [&ctx, stopping](boost::system::error_code, int rc) {
+                        if (rc == 0) ctx.relay_active = !stopping;
+                        ctx.sub_content += rc == 0
+                            ? (stopping ? "  Relay stopped." : "  Relay running.")
+                            : "  Failed (exit " + std::to_string(rc) + ").\n"
+                              "  Ensure companion computer has Docker running and SSH key is configured.";
+                        ctx.sub_content += "\n\n  Press Enter to return.";
+                        render(ctx);
+                    },
+                    boost::process::shell, cmd
+                );
                 break;
             }
             case 2: {
@@ -300,6 +307,15 @@ static void process_command(AppContext& ctx, const std::string& cmd) {
                 break;
             }
             case 3: {
+                if (!ctx.system) {
+                    ctx.sub_content =
+                        "  LIVE TELEMETRY\n\n"
+                        "  No drone connected yet.\n\n"
+                        "  Press Enter to return.";
+                    ctx.state = State::SubMenu;
+                    render(ctx);
+                    break;
+                }
                 ctx.state = State::Monitoring;
                 ctx.telemetry_snap = std::make_shared<TelemetrySnapshot>();
                 ctx.telemetry_plugin = std::make_unique<Telemetry>(ctx.system);
@@ -391,8 +407,14 @@ static void start_qgc_watchdog(AppContext& ctx) {
             if (!sys->has_autopilot() && sys->is_connected()) { found = true; break; }
         }
 
-        if (found != ctx.qgc_connected) {
-            ctx.qgc_connected = found;
+        if (found) {
+            ctx.qgc_miss_count = 0;
+            if (!ctx.qgc_connected) {
+                ctx.qgc_connected = true;
+                request_render(ctx);
+            }
+        } else if (++ctx.qgc_miss_count >= 3 && ctx.qgc_connected) {
+            ctx.qgc_connected = false;
             request_render(ctx);
         }
 
@@ -430,17 +452,7 @@ int main() {
         return -1;
     }
 
-    std::cout << "Waiting for drone..." << std::flush;
-    auto prom = std::make_shared<std::promise<std::shared_ptr<System>>>();
-    auto fut = prom->get_future();
-    auto promise_set = std::make_shared<std::atomic<bool>>(false);
-    sdk.subscribe_on_new_system([&sdk, prom, promise_set]() {
-        for (auto& sys : sdk.systems())
-            if (sys->has_autopilot() && !promise_set->exchange(true))
-                prom->set_value(sys);
-    });
-    std::shared_ptr<System> system{fut.get()};
-    std::cout << " connected.\n" << std::flush;
+    std::shared_ptr<System> system = nullptr;
 
     initscr();
     cbreak();
@@ -460,6 +472,18 @@ int main() {
     ctx.signals.async_wait([&ctx](const boost::system::error_code&, int) {
         endwin();
         ctx.io.stop();
+    });
+
+    auto autopilot_found = std::make_shared<std::atomic<bool>>(false);
+    sdk.subscribe_on_new_system([&sdk, &ctx, autopilot_found]() {
+        for (auto& sys : sdk.systems()) {
+            if (sys->has_autopilot() && !autopilot_found->exchange(true)) {
+                boost::asio::post(ctx.io, [&ctx, sys]() {
+                    ctx.system = sys;
+                    request_render(ctx);
+                });
+            }
+        }
     });
 
     check_relay_once(ctx);


### PR DESCRIPTION
## What's New
- **Remote relay deployment:** MAVLink relay now runs on the companion computer (Raspberry Pi) via Docker over SSH, instead of locally. Deployed directly from the Orbis menu with a single keypress.
- **Non-blocking startup:** TUI launches immediately without waiting for a drone heartbeat — drone system is discovered asynchronously, and Ctrl+C works at all times.
- **SSH key staging:** \`~/.ssh\` is mounted into the container and copied with correct Unix permissions at startup, resolving SSH strict mode rejections from Windows-mounted volumes.
- **Async relay commands:** Start/stop relay runs via \`boost::process::async_system\` so the TUI stays live and responsive during long builds.
- **QGC status debouncing:** 3-miss hysteresis on the QGC watchdog eliminates flickering caused by 1Hz heartbeat / 1Hz poll timing jitter.
- **Display fixes:** \`docker compose\` output redirected to \`/dev/null\` to prevent ncurses corruption; non-ASCII characters replaced with ASCII equivalents.
- **CRLF fix:** \`relay/start-relay.sh\` converted to LF line endings (Windows CRLF caused \`bash\\r: not found\` on the Pi); \`.gitattributes\` added to enforce LF for shell scripts going forward.
- **README:** SSH key setup steps added.